### PR TITLE
Synopsys: Automated PR: Update mockery/1.7.0 to 2.1.0

### DIFF
--- a/tasks/synopsys-detect-task/package-lock.json
+++ b/tasks/synopsys-detect-task/package-lock.json
@@ -215,7 +215,7 @@
       "integrity": "sha512-K7gSptgXzQopg4hZ5ABgPKU5WPeSVX4UfiH9T4lSUdmDw/6+3o4/AXkUFcgPVWGXefNLx6GzHcKYRUE1r+KwZQ==",
       "dependencies": {
         "minimatch": "3.0.4",
-        "mockery": "^1.7.0",
+        "mockery": "^2.1.0",
         "q": "^1.5.1",
         "semver": "^5.1.0",
         "shelljs": "^0.8.4",
@@ -1027,8 +1027,8 @@
       }
     },
     "node_modules/mockery": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/mockery/-/mockery-1.7.0.tgz",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mockery/-/mockery-2.1.0.tgz",
       "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8="
     },
     "node_modules/ms": {
@@ -2046,7 +2046,7 @@
       "integrity": "sha512-K7gSptgXzQopg4hZ5ABgPKU5WPeSVX4UfiH9T4lSUdmDw/6+3o4/AXkUFcgPVWGXefNLx6GzHcKYRUE1r+KwZQ==",
       "requires": {
         "minimatch": "3.0.4",
-        "mockery": "^1.7.0",
+        "mockery": "^2.1.0",
         "q": "^1.5.1",
         "semver": "^5.1.0",
         "shelljs": "^0.8.4",
@@ -2700,8 +2700,8 @@
       }
     },
     "mockery": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/mockery/-/mockery-1.7.0.tgz",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mockery/-/mockery-2.1.0.tgz",
       "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8="
     },
     "ms": {


### PR DESCRIPTION
## Vulnerabilities associated with mockery/1.7.0
[CVE-2022-37614](https://nvd.nist.gov/vuln/detail/CVE-2022-37614) *(CRITICAL)*: Prototype pollution vulnerability in function enable in mockery.js in mfncooper mockery commit 822f0566fd6d72af8c943ae5ca2aa92e516aa2cf via the key variable in mockery.js.

[Click Here To See More Details On Server](https://testing.blackduck.synopsys.com/api/projects/8debd3a8-21f6-4910-b43a-c530afd01543/versions/dcba4d8e-2297-4f1e-9615-844d6236a142/vulnerability-bom?selectedItem=29c3a2a6-3889-4251-af4c-d8c79f75df53)